### PR TITLE
Fix pycodestyle linting errors

### DIFF
--- a/src/staketaxcsv/algo/processor.py
+++ b/src/staketaxcsv/algo/processor.py
@@ -79,7 +79,7 @@ def process_txs(wallet_address, elems, exporter, progress):
             handle_unknown(exporter, txinfo)
 
             if localconfig.debug:
-                raise(e)
+                raise (e)
 
         if i % 50 == 0:
             progress.report(i + 1, "Processed {} of {} transactions".format(i + 1, length))

--- a/src/staketaxcsv/atom/cosmoshub123/processor_1.py
+++ b/src/staketaxcsv/atom/cosmoshub123/processor_1.py
@@ -106,7 +106,7 @@ def handle_transfer(exporter, txinfo, elem, msg_index):
 
 def handle_withdraw_reward(exporter, txinfo, elem, msg_index):
     amount_string = elem["tags"][1]["value"]
-    assert(elem["tags"][1]["key"] == "rewards")
+    assert (elem["tags"][1]["key"] == "rewards")
 
     amount, currency = _amount(amount_string)
 

--- a/src/staketaxcsv/atom/cosmoshub123/processor_2.py
+++ b/src/staketaxcsv/atom/cosmoshub123/processor_2.py
@@ -106,7 +106,7 @@ def handle_transfer(exporter, txinfo, elem, msg_index):
 
 def handle_withdraw_reward(exporter, txinfo, elem, msg_index):
     amount_string = elem["tags"][1]["value"]
-    assert(elem["tags"][1]["key"] == "rewards")
+    assert (elem["tags"][1]["key"] == "rewards")
 
     amount, currency = _amount(amount_string)
 

--- a/src/staketaxcsv/common/Exporter.py
+++ b/src/staketaxcsv/common/Exporter.py
@@ -1061,7 +1061,6 @@ class Exporter:
 
         logging.info("Wrote to %s", csvpath)
 
-
     def export_coinpanda_csv(self, csvpath):
         """ Writes CSV, suitable for import into bitcoin.tax """
         labels = {

--- a/src/staketaxcsv/iotex/processor.py
+++ b/src/staketaxcsv/iotex/processor.py
@@ -41,7 +41,7 @@ def process_tx(wallet_address, elem, exporter):
         handle_unknown(exporter, txinfo)
 
         if localconfig.debug:
-            raise(e)
+            raise (e)
 
 
 def _txinfo(wallet_address, elem):

--- a/src/staketaxcsv/luna1/col4/handle_anchor_bond.py
+++ b/src/staketaxcsv/luna1/col4/handle_anchor_bond.py
@@ -43,7 +43,7 @@ def handle_unbond_withdraw(exporter, elem, txinfo):
 
     sent_amount = received_amount
     sent_currency = CUR_BLUNA
-    assert(received_currency == CUR_LUNA)
+    assert (received_currency == CUR_LUNA)
 
     row = make_swap_tx_terra(txinfo, sent_amount, sent_currency, received_amount, received_currency)
     exporter.ingest_row(row)

--- a/src/staketaxcsv/luna1/col4/handle_anchor_borrow.py
+++ b/src/staketaxcsv/luna1/col4/handle_anchor_borrow.py
@@ -18,7 +18,7 @@ def handle_deposit_collateral(exporter, elem, txinfo):
     collaterals = execute_msg["lock_collateral"]["collaterals"]
     collateral = collaterals[0]
     currency_address, amount = collateral[0], collateral[1]
-    assert(len(collaterals) == 1)
+    assert (len(collaterals) == 1)
 
     sent_currency = util_terra._lookup_address(currency_address, txid)
     sent_amount = util_terra._float_amount(amount, sent_currency)

--- a/src/staketaxcsv/luna1/col4/handle_mirror_borrow.py
+++ b/src/staketaxcsv/luna1/col4/handle_mirror_borrow.py
@@ -31,7 +31,7 @@ def handle_deposit_borrow(exporter, elem, txinfo):
     exporter.ingest_row(row)
 
     try:
-        if(from_contract["is_short"][0] == 'true'):
+        if (from_contract["is_short"][0] == 'true'):
             short_amount_string = data["logs"][0]["events_by_type"]["from_contract"]["return_amount"][0]
             short_amount = util_terra._float_amount(short_amount_string, CUR_UST)
             row = make_swap_tx(txinfo, borrow_amount, borrow_currency, short_amount, CUR_UST)

--- a/src/staketaxcsv/luna1/col4/handle_randomearth.py
+++ b/src/staketaxcsv/luna1/col4/handle_randomearth.py
@@ -54,7 +54,7 @@ def handle_add_to_deposit(exporter, elem, txinfo):
     row = make_nft_deposit(txinfo, sent_amount, sent_currency)
     exporter.ingest_row(row)
 
-    assert(sender == wallet_address)
+    assert (sender == wallet_address)
 
 
 def handle_accept_deposit(exporter, elem, txinfo):
@@ -309,12 +309,12 @@ def handle_execute_order(exporter, elem, txinfo):
 def handle_post_order(exporter, elem, txinfo):
     """ list item from randomearth.io """
     for execute_msg in util_terra._execute_msgs(elem):
-        if("deposit" in execute_msg):
+        if ("deposit" in execute_msg):
             sent_amount, sent_currency = _parse_asset(execute_msg["deposit"]["asset"])
             row = make_nft_offer_deposit(txinfo, sent_amount, sent_currency)
             exporter.ingest_row(row)
 
-        if("post_order" in execute_msg):
+        if ("post_order" in execute_msg):
             order = execute_msg["post_order"]["order"]["order"]
             maker_asset = order["maker_asset"]
             taker_asset = order["taker_asset"]

--- a/src/staketaxcsv/luna1/col4/handle_reward_pylon.py
+++ b/src/staketaxcsv/luna1/col4/handle_reward_pylon.py
@@ -31,7 +31,7 @@ def handle_airdrop_pylon(exporter, elem, txinfo):
 
             # Error checking
             target = from_contract["target"][count]
-            assert(target == wallet_address)
+            assert (target == wallet_address)
 
             count += 1
 

--- a/src/staketaxcsv/luna1/col5/contracts/astroport.py
+++ b/src/staketaxcsv/luna1/col5/contracts/astroport.py
@@ -64,8 +64,8 @@ def _is_astroport_swap(msgs):
 def _handle_astroport_swap(elem, txinfo, msgs):
     txid = txinfo.txid
     send_action, swap_action = msgs[0].actions[0], msgs[0].actions[1]
-    assert(send_action["action"] == "send")
-    assert(swap_action["action"] == "swap")
+    assert (send_action["action"] == "send")
+    assert (swap_action["action"] == "swap")
 
     sent_currency = util_terra._asset_to_currency(swap_action["offer_asset"], txid)
     sent_amount = util_terra._float_amount(send_action["amount"], sent_currency)
@@ -98,8 +98,8 @@ def _handle_astro_stake(elem, txinfo, msgs):
 
     assert (send_action["action"] == "send")
     assert (mint_action["action"] == "mint")
-    assert(receive_currency.upper() == co.CUR_XASTRO)
-    assert(sent_currency.upper() == co.CUR_ASTRO)
+    assert (receive_currency.upper() == co.CUR_XASTRO)
+    assert (sent_currency.upper() == co.CUR_ASTRO)
 
     row = make_swap_tx(txinfo, sent_amount, sent_currency, receive_amount, receive_currency)
     return [row]

--- a/src/staketaxcsv/luna2/contracts/astroport.py
+++ b/src/staketaxcsv/luna2/contracts/astroport.py
@@ -79,6 +79,7 @@ def _handle_provide_liquidity(txinfo, msginfo):
 
     return rows
 
+
 def _is_withdraw_liquidity(actions):
     # example action lists:
     # ["send", "withdraw_liquidity", "burn"]

--- a/src/staketaxcsv/luna2/processor.py
+++ b/src/staketaxcsv/luna2/processor.py
@@ -104,7 +104,6 @@ def _get_contract_data(address):
     return data
 
 
-
 def _handle_unknown(exporter, txinfo):
     row = staketaxcsv.common.make_tx.make_unknown_tx(txinfo)
     exporter.ingest_row(row)

--- a/src/staketaxcsv/report_dvpn.py
+++ b/src/staketaxcsv/report_dvpn.py
@@ -76,8 +76,7 @@ def txhistory(wallet_address, options):
     # LCD - fetch transactions
     lcd_elems = staketaxcsv.common.ibc.api_lcd.get_txs_all(DVPN_LCD_NODE, wallet_address, progress, max_txs,
                                                debug=localconfig.debug,
-                                               stage_name="lcd"
-                                               )
+                                               stage_name="lcd")
 
     # Some older transaction types can no longer be processed through the latest sentinelhub LCD api (version 0.9.2 at time of writing).
     # Example failure message:
@@ -90,8 +89,7 @@ def txhistory(wallet_address, options):
     rpc_elems = staketaxcsv.common.ibc.api_rpc.get_txs_all(DVPN_RPC_NODE, wallet_address, progress, max_txs,
                                                debug=localconfig.debug,
                                                stage_name="rpc",
-                                               events_types=[staketaxcsv.common.ibc.api_common.EVENTS_TYPE_SENDER]
-                                               )
+                                               events_types=[staketaxcsv.common.ibc.api_common.EVENTS_TYPE_SENDER])
 
     # See if there were any missing transactions between the LCD and RPC scans
     lcd_tx_hashes = set([e["txhash"] for e in lcd_elems])

--- a/src/staketaxcsv/sol/handle_raydium_lp.py
+++ b/src/staketaxcsv/sol/handle_raydium_lp.py
@@ -35,11 +35,11 @@ def _handle_raydium_lp(exporter, txinfo):
           and len(transfers_in) == 2
           and len(transfers_out) == 1):
         _handle_raydium_lp_withdraw(exporter, txinfo, transfers_in, transfers_out)
-    elif("process_swap:" in log_string
+    elif ("process_swap:" in log_string
          and len(transfers_in) == 1
          and len(transfers_out) == 1):
         _handle_raydium_swap(exporter, txinfo, transfers_in, transfers_out)
-    elif("process_swap_base_in:" in log_string
+    elif ("process_swap_base_in:" in log_string
          and len(transfers_in) == 1
          and len(transfers_out) == 1):
         _handle_raydium_swap(exporter, txinfo, transfers_in, transfers_out)


### PR DESCRIPTION
```
./src/staketaxcsv/report_dvpn.py:80:48: E124 closing bracket does not match visual indentation
./src/staketaxcsv/report_dvpn.py:94:48: E124 closing bracket does not match visual indentation
./src/staketaxcsv/luna2/processor.py:108:1: E303 too many blank lines (3)
./src/staketaxcsv/luna2/contracts/astroport.py:82:1: E302 expected 2 blank lines, found 1
./src/staketaxcsv/iotex/processor.py:44:18: E275 missing whitespace after keyword
./src/staketaxcsv/atom/cosmoshub123/processor_1.py:109:11: E275 missing whitespace after keyword
./src/staketaxcsv/atom/cosmoshub123/processor_2.py:109:11: E275 missing whitespace after keyword
./src/staketaxcsv/sol/handle_raydium_lp.py:38:9: E275 missing whitespace after keyword
./src/staketaxcsv/sol/handle_raydium_lp.py:42:9: E275 missing whitespace after keyword
./src/staketaxcsv/algo/processor.py:82:22: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col5/contracts/astroport.py:67:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col5/contracts/astroport.py:68:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col5/contracts/astroport.py:101:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col5/contracts/astroport.py:102:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col4/handle_anchor_bond.py:46:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col4/handle_anchor_borrow.py:21:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col4/handle_mirror_borrow.py:34:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col4/handle_randomearth.py:57:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col4/handle_randomearth.py:312:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col4/handle_randomearth.py:317:11: E275 missing whitespace after keyword
./src/staketaxcsv/luna1/col4/handle_reward_pylon.py:34:19: E275 missing whitespace after keyword
```